### PR TITLE
Destroy db connection after each test run

### DIFF
--- a/backend/src/api/addresses/addresses.test.js
+++ b/backend/src/api/addresses/addresses.test.js
@@ -1,6 +1,9 @@
 const supertest = require('supertest');
 
 const app = require('../../app');
+const connection = require('../../db');
+
+afterAll(() => connection.destroy());
 
 describe('GET /api/v1/addresses', () => {
   it('should respond with an array of addresses', async () => {

--- a/backend/src/api/companies/companies.test.js
+++ b/backend/src/api/companies/companies.test.js
@@ -1,6 +1,9 @@
 const supertest = require('supertest');
 
 const app = require('../../app');
+const connection = require('../../db');
+
+afterAll(() => connection.destroy());
 
 describe('GET /api/v1/companies', () => {
   it('should respond with an array of companies', async () => {

--- a/backend/src/api/items/items.test.js
+++ b/backend/src/api/items/items.test.js
@@ -1,6 +1,9 @@
 const supertest = require('supertest');
 
 const app = require('../../app');
+const connection = require('../../db');
+
+afterAll(() => connection.destroy());
 
 describe('GET /api/v1/items', () => {
   it('should respond with an array of items', async () => {

--- a/backend/src/api/states/states.test.js
+++ b/backend/src/api/states/states.test.js
@@ -1,6 +1,9 @@
 const supertest = require('supertest');
 
 const app = require('../../app');
+const connection = require('../../db');
+
+afterAll(() => connection.destroy());
 
 describe('GET /api/v1/states', () => {
   it('should respond with an array of states', async () => {

--- a/backend/src/api/users/users.test.js
+++ b/backend/src/api/users/users.test.js
@@ -1,6 +1,9 @@
 const supertest = require('supertest');
 
 const app = require('../../app');
+const connection = require('../../db');
+
+afterAll(() => connection.destroy());
 
 describe('GET /api/v1/users', () => {
   it('should respond with an array of users', async () => {


### PR DESCRIPTION
Fixes #6 

The `globalTeardown `function doesn't seem to completely destroy all db connections and leaves jest hanging, so we can manually destroy them after each test suite is run.